### PR TITLE
Furina Patch

### DIFF
--- a/NPCData/Furina(NPC) pre4-2/hash.json
+++ b/NPCData/Furina(NPC) pre4-2/hash.json
@@ -36,7 +36,7 @@
         "position_vb": "330c6649",
         "blend_vb": "85735ea7",
         "texcoord_vb": "513c176c",
-        "ib": "045e580b",
+        "ib": "d672c825",
         "object_indexes": [
             0,
             57015,

--- a/PlayerCharacterData/Freminet/hash.json
+++ b/PlayerCharacterData/Freminet/hash.json
@@ -6,7 +6,7 @@
         "position_vb": "d2bfc751",
         "blend_vb": "4443153c",
         "texcoord_vb": "333aa56c",
-        "ib": "1812a5f8",
+        "ib": "6d40de64",
         "object_indexes": [
             0,
             36975

--- a/PlayerCharacterData/Furina/hash.json
+++ b/PlayerCharacterData/Furina/hash.json
@@ -6,7 +6,7 @@
         "position_vb": "8294fe98",
         "blend_vb": "d8c43862",
         "texcoord_vb": "a327ea5e",
-        "ib": "3c8a32d4",
+        "ib": "045e580b",
         "object_indexes": [
             0,
             57279,

--- a/PlayerCharacterData/Tighnari/hash.json
+++ b/PlayerCharacterData/Tighnari/hash.json
@@ -6,7 +6,7 @@
         "position_vb": "531187c9",
         "blend_vb": "86c195a8",
         "texcoord_vb": "a95a82aa",
-        "ib": "bfeab9d1",
+        "ib": "69a807fc",
         "object_indexes": [
             0,
             44868,


### PR DESCRIPTION
The hashes in the script to generate the changes was errant.
These should be the correct hashes.

Basically, the old hash in the script was changed to the old NPC hash and the New Playable hash.
I've already added them to the Google Doc. But I can't do anything about the 4.3 script.
I figured it was easier to manually update them here.

Tighnari was not updated before and now is.